### PR TITLE
Fix ResNet-1 architecture and create Dropout-4 model

### DIFF
--- a/ml/models/resnet.py
+++ b/ml/models/resnet.py
@@ -154,6 +154,44 @@ class ResNetDropoutV3(ResNetDropoutV1):
         return x
 
 
+class ResNetDropoutV4(ResNetStyleV1):
+    """
+    Use 2-D dropout in all skip-connected blocks. The dropout is placed
+    after the conv2d layer in the residual branch. 
+    """
+    def __init__(self):
+        super().__init__()
+
+        self.res2 = SkipConnection(
+            nn.Sequential(
+                ConvBlock(32, 32, kernel_size=3, stride=1, padding=1), 
+                nn.Conv2d(32, 32, kernel_size=3, stride=1, padding=1), 
+                nn.Dropout2d(0.1), 
+            )
+        )
+        # Output shape = (B, 32, 32, 32)
+
+        self.res3 = SkipConnection(
+            nn.Sequential(
+                ConvBlock(32, 64, kernel_size=3, stride=2, padding=1), 
+                nn.Conv2d(64, 64, kernel_size=3, stride=1, padding=1), 
+                nn.Dropout2d(0.1), 
+            ), 
+            downsample=nn.Conv2d(32, 64, kernel_size=3, stride=2, padding=1)
+        )
+        # Output shape = (B, 64, 16, 16)
+
+        self.res4 = SkipConnection(
+            nn.Sequential(
+                ConvBlock(64, 128, kernel_size=3, stride=2, padding=1), 
+                nn.Conv2d(128, 128, kernel_size=3, stride=1, padding=1), 
+                nn.Dropout2d(0.1), 
+            ), 
+            downsample=nn.Conv2d(64, 128, kernel_size=3, stride=2, padding=1)
+        )
+        # Output shape = (B, 128, 8, 8)
+
+
 class ResNetWDecayV1(ResNetStyleV1):
     def __init__(self):
         super(ResNetWDecayV1, self).__init__()

--- a/ml/models/resnet.py
+++ b/ml/models/resnet.py
@@ -77,12 +77,20 @@ class ResNetDropoutV1(ResNetStyleV1):
 
     def forward(self, x):
         x = self.conv1(x)
-        x = self.res1(x)
+
         x = self.res2(x)
+        x = self.relu(x)
+
         x = self.res3(x)
-        x = self.pool4(x)
+        x = self.relu(x)
+
+        x = self.res4(x)
+        x = self.relu(x)
+
+        x = self.pool5(x)
         x = self.flatten(x)
-        x = self.fc5(x)
+
+        x = self.fc6(x)
         x = self.dropout(x)
 
         return x
@@ -97,13 +105,21 @@ class ResNetDropoutV2(ResNetDropoutV1):
 
     def forward(self, x):
         x = self.conv1(x)
-        x = self.res1(x)
+
         x = self.res2(x)
+        x = self.relu(x)
+
         x = self.res3(x)
-        x = self.pool4(x)
-        x = self.dropout(x)
+        x = self.relu(x)
+
+        x = self.res4(x)
+        x = self.relu(x)
+
+        x = self.pool5(x)
         x = self.flatten(x)
-        x = self.fc5(x)
+        x = self.dropout(x)
+
+        x = self.fc6(x)
 
         return x
 
@@ -115,15 +131,25 @@ class ResNetDropoutV3(ResNetDropoutV1):
     def __init__(self):
         super(ResNetDropoutV3, self).__init__()
 
+        self.dropout2d = nn.Dropout2d(0.5)
+
     def forward(self, x):
         x = self.conv1(x)
-        x = self.res1(x)
+
         x = self.res2(x)
+        x = self.relu(x)
+
         x = self.res3(x)
-        x = self.dropout(x)
-        x = self.pool4(x)
+        x = self.relu(x)
+
+        x = self.res4(x)
+        x = self.relu(x)
+
+        x = self.dropout2d(x)
+        x = self.pool5(x)
         x = self.flatten(x)
-        x = self.fc5(x)
+
+        x = self.fc6(x)
 
         return x
 

--- a/ml/models/resnet.py
+++ b/ml/models/resnet.py
@@ -1,4 +1,5 @@
 import torch.nn as nn
+import torch.nn.functional as F
 import torch.optim as optim
 from .utils import Model, ConvBlock, SkipConnection
 
@@ -7,53 +8,62 @@ class ResNetStyleV1(Model):
     def __init__(self):
         super(ResNetStyleV1, self).__init__()
 
+        self.relu = nn.ReLU()
         # Input shape = (B, 3, 32, 32)
         self.conv1 = ConvBlock(3, 32, kernel_size=3, stride=1, padding=1)
         #  Output shape = (B, 32, 32, 32)
 
-        self.res1 = SkipConnection(
+        self.res2 = SkipConnection(
             nn.Sequential(
                 ConvBlock(32, 32, kernel_size=3, stride=1, padding=1), 
-                ConvBlock(32, 32, kernel_size=3, stride=1, padding=1)
+                nn.Conv2d(32, 32, kernel_size=3, stride=1, padding=1)
             )
         )
         # Output shape = (B, 32, 32, 32)
 
-        self.res2 = SkipConnection(
+        self.res3 = SkipConnection(
             nn.Sequential(
                 ConvBlock(32, 64, kernel_size=3, stride=2, padding=1), 
-                ConvBlock(64, 64, kernel_size=3, stride=1, padding=1)
+                nn.Conv2d(64, 64, kernel_size=3, stride=1, padding=1)
             ), 
             downsample=nn.Conv2d(32, 64, kernel_size=3, stride=2, padding=1)
         )
         # Output shape = (B, 64, 16, 16)
 
-        self.res3 = SkipConnection(
+        self.res4 = SkipConnection(
             nn.Sequential(
                 ConvBlock(64, 128, kernel_size=3, stride=2, padding=1), 
-                ConvBlock(128, 128, kernel_size=3, stride=1, padding=1)
+                nn.Conv2d(128, 128, kernel_size=3, stride=1, padding=1)
             ), 
             downsample=nn.Conv2d(64, 128, kernel_size=3, stride=2, padding=1)
         )
         # Output shape = (B, 128, 8, 8)
 
-        self.pool4 = nn.AdaptiveAvgPool2d((1, 1))
+        self.pool5 = nn.AdaptiveAvgPool2d((1, 1))
         # Output shape = (B, 128, 1, 1)
 
         self.flatten = nn.Flatten(1)
         # Output shape = (B, 128)
 
-        self.fc5 = nn.Linear(128, 10)
+        self.fc6 = nn.Linear(128, 10)
 
 
     def forward(self, x):
         x = self.conv1(x)
-        x = self.res1(x)
+
         x = self.res2(x)
+        x = self.relu(x)
+
         x = self.res3(x)
-        x = self.pool4(x)
+        x = self.relu(x)
+
+        x = self.res4(x)
+        x = self.relu(x)
+
+        x = self.pool5(x)
         x = self.flatten(x)
-        x = self.fc5(x)
+
+        x = self.fc6(x)
 
         return x
     

--- a/train/improved/resnet_dropout_v4.py
+++ b/train/improved/resnet_dropout_v4.py
@@ -1,0 +1,24 @@
+import os
+from ml.models import ResNetDropoutV4
+from ml.pipelines import run_pipeline
+
+
+if __name__ == "__main__":
+    MODEL = ResNetDropoutV4()
+    BATCH_SIZE = 64
+    NUM_EPOCHS = 100
+    NUM_WORKERS = os.cpu_count()
+    VAL_SIZE = 0.05
+    EXPERIMENT_NAME = "resnet-style-cnn"
+    RANDOM_STATE = 0
+
+    run_pipeline(
+        MODEL, 
+        BATCH_SIZE, 
+        NUM_EPOCHS, 
+        NUM_WORKERS, 
+        VAL_SIZE, 
+        EXPERIMENT_NAME, 
+        RANDOM_STATE
+    )
+    


### PR DESCRIPTION
- fix ResNet-1's architecture to use ReLU AFTER the main + residual operation in the skip-connected block.
- fix architecture changes of ResNet-1 in the models that extend it.
- create Dropout-4 model
- create a training script
